### PR TITLE
fix: guard cache hit rate calculation

### DIFF
--- a/src/core/memory-engine.ts
+++ b/src/core/memory-engine.ts
@@ -495,8 +495,9 @@ export class MemoryEngine {
   }
 
   getCacheStats(): CacheStats {
+    const totalRequests = this.stats.hits + this.stats.misses;
     this.stats.hitRate =
-      (this.stats.hits / (this.stats.hits + this.stats.misses)) * 100;
+      totalRequests > 0 ? (this.stats.hits / totalRequests) * 100 : 0;
     this.stats.memory = process.memoryUsage().heapUsed;
     return { ...this.stats };
   }


### PR DESCRIPTION
## Summary
- avoid dividing by zero when calculating cache hit rate so stats stay at 0% before any requests occur

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda3c65410832a8f90fb273495a7cb