### PR TITLE
Align website to canonical wireframe design tokens (@n3wth/ui 0.9.1)

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -16,23 +16,23 @@ export async function generateStaticParams() {
 const components = {
   ...MDXComponents,
   h1: ({ children }: any) => (
-    <h1 className="text-4xl font-normal text-white mb-6">{children}</h1>
+    <h1 className="text-4xl font-normal text-ink mb-6">{children}</h1>
   ),
   h2: ({ children }: any) => (
-    <h2 className="text-2xl font-normal text-white mt-12 mb-4">{children}</h2>
+    <h2 className="text-2xl font-normal text-ink mt-12 mb-4">{children}</h2>
   ),
   h3: ({ children }: any) => (
-    <h3 className="text-lg font-medium text-white mt-8 mb-3">{children}</h3>
+    <h3 className="text-lg font-medium text-ink mt-8 mb-3">{children}</h3>
   ),
   p: ({ children }: any) => (
-    <p className="text-gray-400 mb-4 leading-relaxed">{children}</p>
+    <p className="text-ink-dim mb-4 leading-relaxed">{children}</p>
   ),
   ul: ({ children }: any) => (
-    <ul className="text-gray-400 mb-4 space-y-2 list-disc list-inside">
+    <ul className="text-ink-dim mb-4 space-y-2 list-disc list-inside">
       {children}
     </ul>
   ),
-  li: ({ children }: any) => <li className="text-gray-400">{children}</li>,
+  li: ({ children }: any) => <li className="text-ink-dim">{children}</li>,
   a: ({ href, children }: any) => {
     // Handle external links
     if (href?.startsWith("http")) {
@@ -41,7 +41,7 @@ const components = {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-400 hover:text-blue-300 transition-colors"
+          className="text-accent-dim hover:text-accent transition-colors"
         >
           {children}
         </a>
@@ -51,34 +51,34 @@ const components = {
     return (
       <Link
         href={href || "#"}
-        className="text-blue-400 hover:text-blue-300 transition-colors"
+        className="text-accent-dim hover:text-accent transition-colors"
       >
         {children}
       </Link>
     );
   },
   strong: ({ children }: any) => (
-    <strong className="text-white font-medium">{children}</strong>
+    <strong className="text-ink font-medium">{children}</strong>
   ),
   table: ({ children }: any) => (
     <div className="overflow-x-auto mb-6">
-      <table className="min-w-full divide-y divide-white/10">{children}</table>
+      <table className="min-w-full divide-y divide-rail">{children}</table>
     </div>
   ),
   thead: ({ children }: any) => (
-    <thead className="bg-white/[0.02]">{children}</thead>
+    <thead className="bg-bg-soft">{children}</thead>
   ),
   tbody: ({ children }: any) => (
-    <tbody className="divide-y divide-white/10">{children}</tbody>
+    <tbody className="divide-y divide-rail">{children}</tbody>
   ),
   tr: ({ children }: any) => <tr>{children}</tr>,
   th: ({ children }: any) => (
-    <th className="px-4 py-3 text-left text-sm font-medium text-white">
+    <th className="px-4 py-3 text-left text-sm font-medium text-ink">
       {children}
     </th>
   ),
   td: ({ children }: any) => (
-    <td className="px-4 py-3 text-sm text-gray-400">{children}</td>
+    <td className="px-4 py-3 text-sm text-ink-dim">{children}</td>
   ),
 };
 
@@ -118,11 +118,11 @@ export default async function DocPage({
       </article>
 
       {/* Navigation */}
-      <div className="flex items-center justify-between mt-16 pt-8 border-t border-white/10">
+      <div className="flex items-center justify-between mt-16 pt-8 border-t border-rail">
         {prevDoc ? (
           <Link
             href={`/docs/${prevDoc.slug}`}
-            className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+            className="flex items-center gap-2 text-ink-dim hover:text-ink transition-colors"
           >
             <ArrowLeft className="h-4 w-4" />
             {prevDoc.title}
@@ -134,7 +134,7 @@ export default async function DocPage({
         {nextDoc && (
           <Link
             href={`/docs/${nextDoc.slug}`}
-            className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+            className="flex items-center gap-2 text-ink-dim hover:text-ink transition-colors"
           >
             {nextDoc.title}
             <ArrowRight className="h-4 w-4" />

--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -10,7 +10,7 @@ export default function DocsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-black">
+    <div className="min-h-screen bg-bg">
       <Navigation />
       <DocsHeader />
 

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1,14 +1,18 @@
 @import "tailwindcss";
 @import "@n3wth/ui/styles";
+/* source of truth: @n3wth/ui/theme (canonical wireframe tokens) */
+@import "@n3wth/ui/theme";
 @import "../styles/animations.css";
 
 @source "../node_modules/@n3wth/ui/dist";
 
 @layer base {
   :root {
-    /* Override accent for r3 brand - subtle purple tint */
-    --color-accent: #a78bfa;
-    --color-accent-soft: rgba(167, 139, 250, 0.15);
+    /* Geist for display AND body (canonical). Loaded via next/font in layout.tsx. */
+    --font-sans: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
+    --font-display: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
+    --font-mono: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
+    --font-brand: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
   }
 
   html {
@@ -16,115 +20,22 @@
   }
 
   body {
-    font-family: var(--font-sans, 'Geist Sans', system-ui, sans-serif);
+    font-family: var(--font-sans, system-ui, sans-serif);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background: var(--color-bg, #000000);
-    color: var(--color-white, #ffffff);
+    background: var(--color-bg, #08090b);
+    color: var(--color-ink, #f2f3f5);
     overflow-x: hidden;
     min-height: 100vh;
   }
 
   code {
-    font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
+    font-family: var(--font-mono, ui-monospace, monospace);
   }
 
   /* Selection styling */
   ::selection {
     background: var(--color-accent-soft);
-    color: var(--color-white);
+    color: var(--color-ink);
   }
-}
-
-/* Custom animations for r3 */
-@keyframes float {
-  0%, 100% { transform: translateY(0) translateX(0); }
-  25% { transform: translateY(-10px) translateX(5px); }
-  50% { transform: translateY(5px) translateX(-5px); }
-  75% { transform: translateY(-5px) translateX(10px); }
-}
-
-@keyframes pulse-glow {
-  0%, 100% { opacity: 0.1; transform: scale(1); }
-  50% { opacity: 0.15; transform: scale(1.02); }
-}
-
-@keyframes morph {
-  0%, 100% {
-    border-radius: 50%;
-    transform: scale(1) rotate(0deg);
-  }
-  33% {
-    border-radius: 45% 55% 52% 48%;
-    transform: scale(1.05) rotate(120deg);
-  }
-  66% {
-    border-radius: 52% 48% 45% 55%;
-    transform: scale(0.95) rotate(240deg);
-  }
-}
-
-@keyframes slide-up {
-  from { transform: translateY(30px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
-}
-
-@keyframes spin-slow {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@keyframes aurora {
-  0%, 100% { transform: translateY(100%); opacity: 0; }
-  20% { opacity: 0.3; }
-  50% { transform: translateY(-100%); opacity: 0.3; }
-  80% { opacity: 0.3; }
-}
-
-@keyframes gradient {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}
-
-.animate-spin-slow {
-  animation: spin-slow 3s linear infinite;
-}
-
-.animate-aurora {
-  animation: aurora 20s ease-in-out infinite;
-}
-
-.animate-gradient {
-  animation: gradient 8s ease infinite;
-  background-size: 300% 300%;
-}
-
-.bg-300\% {
-  background-size: 300% 300%;
-}
-
-/* Glass effect using design tokens */
-.glass-effect {
-  background: var(--glass-bg, rgba(255, 255, 255, 0.05));
-  backdrop-filter: blur(10px);
-  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
-}
-
-/* Parallax layers for depth */
-.parallax-back {
-  transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  transform: translate(-50%, -50%) translateY(calc(var(--scroll-y, 0) * -5px))
-    scale(calc(1 - var(--scroll-y, 0) * 0.02));
-}
-
-.parallax-mid {
-  transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  transform: translate(-50%, -50%) translateY(calc(var(--scroll-y, 0) * -10px))
-    scale(calc(1 - var(--scroll-y, 0) * 0.03));
-}
-
-.parallax-front {
-  transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  transform: translate(-50%, -50%) translateY(calc(var(--scroll-y, 0) * -15px))
-    scale(calc(1 - var(--scroll-y, 0) * 0.04));
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -6,15 +6,16 @@
 
 @source "../node_modules/@n3wth/ui/dist";
 
-@layer base {
-  :root {
-    /* Geist for display AND body (canonical). Loaded via next/font in layout.tsx. */
-    --font-sans: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
-    --font-display: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
-    --font-mono: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
-    --font-brand: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
-  }
+/* Geist for display AND body (canonical). Loaded via next/font in layout.tsx.
+   Unlayered so it wins over @n3wth/ui's compiled :root declarations. */
+:root {
+  --font-sans: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
+  --font-display: var(--font-geist-sans), "Geist Sans", system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
+  --font-brand: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
+}
 
+@layer base {
   html {
     overflow-x: hidden;
   }

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -82,7 +82,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
       <AxiomWebVitals />
       <head>
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -125,7 +129,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
+        className="antialiased min-h-screen"
         suppressHydrationWarning
       >
         <PostHogProvider>

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, JetBrains_Mono } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { AxiomWebVitals } from "next-axiom";
 import { PostHogProvider } from "../components/PostHogProvider";
@@ -17,13 +17,6 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
   display: "swap",
   preload: false, // Only preload if needed
-});
-
-const jetBrainsMono = JetBrains_Mono({
-  variable: "--font-brand",
-  subsets: ["latin"],
-  display: "swap",
-  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -112,7 +105,7 @@ export default function RootLayout({
           href="/favicon-16x16.png"
         />
         <link rel="manifest" href="/site.webmanifest" />
-        <meta name="theme-color" content="#4F46E5" />
+        <meta name="theme-color" content="#08090b" />
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -132,7 +125,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${jetBrainsMono.variable} antialiased min-h-screen`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
         suppressHydrationWarning
       >
         <PostHogProvider>

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -14,14 +14,15 @@ export default async function Image() {
       <div
         style={{
           fontSize: 128,
-          background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+          /* source of truth: @n3wth/ui/theme */
+          background: "#08090b",
           width: "100%",
           height: "100%",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          color: "white",
+          color: "#f2f3f5",
         }}
       >
         <div

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -33,12 +33,6 @@ const TerminalDemo = lazy(() =>
     default: module.TerminalDemo,
   })),
 );
-const Meteors = lazy(() =>
-  import("@/components/magicui/meteors").then((module) => ({
-    default: module.Meteors,
-  })),
-);
-
 export default function Home() {
   const [activeTab, setActiveTab] = useState("node");
 
@@ -81,7 +75,7 @@ const context = await recall.search({
   };
 
   return (
-    <div className="flex flex-col min-h-screen bg-black">
+    <div className="flex flex-col min-h-screen bg-bg">
       <Navigation />
 
       {/* Main content wrapper */}
@@ -93,23 +87,17 @@ const context = await recall.search({
             <MemoryVisualization />
           </div>
 
-          {/* Gradient background */}
-          <div className="absolute inset-0 pointer-events-none">
-            <div className="absolute inset-0 bg-gradient-to-b from-purple-950/20 via-black to-black" />
-            <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(120,100,255,0.12),transparent_60%)]" />
-          </div>
-
           <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 text-center">
             <div className="mx-auto max-w-4xl">
               {/* Professional value prop badge - mobile-optimized */}
-              <div className="mb-4 sm:mb-6 inline-flex items-center gap-2 rounded-full bg-white/[0.03] backdrop-blur-sm px-2.5 sm:px-3 py-1 sm:py-1.5 text-[10px] sm:text-xs font-medium border border-white/[0.08]">
-                <span className="text-white sm:hidden whitespace-nowrap">
+              <div className="mb-4 sm:mb-6 inline-flex items-center gap-2 rounded-full bg-bg-soft px-2.5 sm:px-3 py-1 sm:py-1.5 text-[10px] sm:text-xs font-medium border border-rail">
+                <span className="text-ink sm:hidden whitespace-nowrap">
                   AI Memory
                 </span>
                 <span className="hidden sm:inline-flex sm:items-center sm:gap-3">
-                  <span className="text-purple-300">Memory MCP server</span>
-                  <span className="text-white/40">×</span>
-                  <span className="text-blue-300">Open source</span>
+                  <span className="text-ink">Memory MCP server</span>
+                  <span className="text-ink-faint">×</span>
+                  <span className="text-ink">Open source</span>
                 </span>
               </div>
 
@@ -118,7 +106,7 @@ const context = await recall.search({
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
-                  className="text-white block"
+                  className="text-ink block"
                 >
                   Give your AI
                 </motion.span>
@@ -130,24 +118,24 @@ const context = await recall.search({
                     delay: 0.2,
                     ease: [0.16, 1, 0.3, 1],
                   }}
-                  className="text-white inline-block mt-1"
+                  className="text-ink inline-block mt-1"
                 >
                   permanent memory
                 </motion.span>
               </h1>
 
               {/* Mobile-first subtitle */}
-              <p className="mx-auto max-w-2xl text-sm sm:text-base lg:text-lg text-white/90 mb-6 sm:mb-8 md:mb-10 font-light leading-relaxed px-0">
+              <p className="mx-auto max-w-2xl text-sm sm:text-base lg:text-lg text-ink-dim mb-6 sm:mb-8 md:mb-10 font-light leading-relaxed px-0">
                 <span className="sm:hidden">
                   Context that persists across every AI conversation. Works with Claude, GPT, and Gemini.
                 </span>
                 <span className="hidden sm:inline">
                   Your AI assistant remembers what you talked about last session.{" "}
-                  <span className="text-white font-medium">
+                  <span className="text-ink font-medium">
                     Redis caching
                   </span>{" "}
                   and{" "}
-                  <span className="text-white font-medium">
+                  <span className="text-ink font-medium">
                     vector search
                   </span>{" "}
                   keep context fast and relevant. Works with Claude, GPT, and Gemini via MCP.
@@ -186,10 +174,10 @@ const context = await recall.search({
                   }}
                   className="text-center"
                 >
-                  <div className="text-lg sm:text-xl md:text-2xl font-light text-white">
+                  <div className="text-lg sm:text-xl md:text-2xl font-light text-ink">
                     <AnimatedCounter to={5} suffix="ms" duration={1.5} />
                   </div>
-                  <div className="text-[10px] sm:text-xs md:text-sm text-white/60 mt-1">
+                  <div className="text-[10px] sm:text-xs md:text-sm text-ink-dim mt-1">
                     Response time
                   </div>
                 </motion.div>
@@ -204,10 +192,10 @@ const context = await recall.search({
                   }}
                   className="text-center"
                 >
-                  <div className="text-lg sm:text-xl md:text-2xl font-light text-white">
+                  <div className="text-lg sm:text-xl md:text-2xl font-light text-ink">
                     <AnimatedCounter to={384} duration={1.5} />
                   </div>
-                  <div className="text-[10px] sm:text-xs md:text-sm text-white/60 mt-1">
+                  <div className="text-[10px] sm:text-xs md:text-sm text-ink-dim mt-1">
                     Dimensions per vector
                   </div>
                 </motion.div>
@@ -222,10 +210,10 @@ const context = await recall.search({
                   }}
                   className="text-center sm:col-span-1 col-span-1"
                 >
-                  <div className="text-lg sm:text-xl md:text-2xl font-light text-white">
+                  <div className="text-lg sm:text-xl md:text-2xl font-light text-ink">
                     <AnimatedCounter to={0} duration={1.5} />
                   </div>
-                  <div className="text-[10px] sm:text-xs md:text-sm text-white/60 mt-1">
+                  <div className="text-[10px] sm:text-xs md:text-sm text-ink-dim mt-1">
                     Cloud dependencies
                   </div>
                 </motion.div>
@@ -240,10 +228,10 @@ const context = await recall.search({
                   }}
                   className="text-center col-span-1"
                 >
-                  <div className="text-lg sm:text-xl md:text-2xl font-light text-white">
+                  <div className="text-lg sm:text-xl md:text-2xl font-light text-ink">
                     <AnimatedCounter to={1} duration={1.5} />
                   </div>
-                  <div className="text-[10px] sm:text-xs md:text-sm text-white/60 mt-1">
+                  <div className="text-[10px] sm:text-xs md:text-sm text-ink-dim mt-1">
                     Command to install
                   </div>
                 </motion.div>
@@ -256,8 +244,7 @@ const context = await recall.search({
         <MemoryComparison />
 
         {/* Interactive Terminal Demo */}
-        <Section spacing="lg" className="border-t border-white/[0.06] relative overflow-hidden">
-          <Meteors number={20} />
+        <Section spacing="lg" className="border-t border-rail relative overflow-hidden">
           <Container size="lg">
             <ScrollReveal className="max-w-4xl mx-auto relative z-10">
               <SectionHeader
@@ -268,7 +255,7 @@ const context = await recall.search({
               />
               <Suspense
                 fallback={
-                  <div className="bg-gray-900 rounded-lg p-6 animate-pulse h-64" />
+                  <div className="bg-bg-soft rounded-lg p-6 animate-pulse h-64" />
                 }
               >
                 <TerminalDemo />
@@ -278,7 +265,7 @@ const context = await recall.search({
         </Section>
 
         {/* Code Example - Clean tabs */}
-        <Section spacing="lg" className="border-t border-white/[0.06]">
+        <Section spacing="lg" className="border-t border-rail">
           <Container size="lg">
             <ScrollReveal className="max-w-4xl mx-auto">
               <SectionHeader
@@ -289,7 +276,7 @@ const context = await recall.search({
               />
 
               <div className="relative">
-                <div className="border-b border-white/[0.08] bg-white/[0.02] rounded-t-xl">
+                <div className="border-b border-rail bg-bg-soft rounded-t-xl">
                   <nav className="flex" aria-label="Tabs">
                     {Object.keys(codeExamples).map((lang) => (
                       <button
@@ -299,8 +286,8 @@ const context = await recall.search({
                         flex-1 px-4 py-3 text-sm font-medium capitalize transition-all
                         ${
                           activeTab === lang
-                            ? "text-white border-b-2 border-white/80"
-                            : "text-gray-500 hover:text-gray-300"
+                            ? "text-ink border-b-2 border-accent"
+                            : "text-ink-faint hover:text-ink-dim"
                         }
                       `}
                       >
@@ -326,7 +313,7 @@ const context = await recall.search({
         </Section>
 
         {/* Features - Bento Grid */}
-        <Section spacing="lg" className="border-t border-white/[0.06] relative">
+        <Section spacing="lg" className="border-t border-rail relative">
           <Container size="lg">
             <ScrollReveal>
             <SectionHeader
@@ -341,7 +328,7 @@ const context = await recall.search({
                 title="Semantic Search"
                 description="Query stored context using natural language. Cosine similarity ranking across 384-dimension vectors."
                 icon={
-                  <Cpu className="h-5 w-5 text-gray-400" />
+                  <Cpu className="h-5 w-5 text-ink-dim" />
                 }
                 span="lg:col-span-2"
               />
@@ -350,7 +337,7 @@ const context = await recall.search({
                 title="Knowledge Graph"
                 description="Automatic entity extraction links memories into a traversable graph of relationships."
                 icon={
-                  <Layers className="h-5 w-5 text-gray-400" />
+                  <Layers className="h-5 w-5 text-ink-dim" />
                 }
               />
 
@@ -358,28 +345,28 @@ const context = await recall.search({
                 title="Sub-10ms responses"
                 description="Embedded Redis serves as both cache layer and vector store. Local embedding generation, no API calls."
                 icon={
-                  <Zap className="h-5 w-5 text-gray-400" />
+                  <Zap className="h-5 w-5 text-ink-dim" />
                 }
               />
 
               <BentoCard
                 title="MCP compatible"
                 description="Works with Claude Desktop, Claude Code, Gemini CLI, and any MCP client out of the box."
-                icon={<Globe className="h-5 w-5 text-gray-400" />}
+                icon={<Globe className="h-5 w-5 text-ink-dim" />}
                 span="lg:col-span-2"
               />
 
               <BentoCard
                 title="TypeScript SDK"
                 description="Typed memory operations, search results, and configuration. Ships its own type declarations."
-                icon={<Code className="h-5 w-5 text-gray-400" />}
+                icon={<Code className="h-5 w-5 text-ink-dim" />}
                 span="lg:col-span-2"
               />
 
               <BentoCard
                 title="Zero dependencies"
                 description="Embedded Redis server, local vector store. No cloud services, no API keys, no configuration files."
-                icon={<Lock className="h-5 w-5 text-gray-400" />}
+                icon={<Lock className="h-5 w-5 text-ink-dim" />}
               />
             </BentoGrid>
             </ScrollReveal>
@@ -387,13 +374,13 @@ const context = await recall.search({
         </Section>
 
         {/* Bottom CTA section */}
-        <Section spacing="lg" className="border-t border-white/[0.06]">
+        <Section spacing="lg" className="border-t border-rail">
           <Container size="sm">
             <ScrollReveal className="text-center">
-              <p className="text-xl sm:text-2xl text-gray-300 mb-2 font-light">
+              <p className="text-xl sm:text-2xl text-ink-dim mb-2 font-light">
                 Your AI forgets everything between sessions.
               </p>
-              <p className="text-xl sm:text-2xl text-white font-medium mb-8">
+              <p className="text-xl sm:text-2xl text-ink font-medium mb-8">
                 One command fixes that.
               </p>
               <div className="flex justify-center">

--- a/website/components/AnimatedCounter.tsx
+++ b/website/components/AnimatedCounter.tsx
@@ -44,7 +44,7 @@ export function AnimatedCounter({
     if (inView) {
       const controls = animate(motionValue, to, {
         duration,
-        ease: [0.25, 0.46, 0.45, 0.94],
+        ease: [0.16, 1, 0.3, 1],
         onUpdate: (latest) => {
           const value =
             decimals > 0

--- a/website/components/ArchitectureDiagram.tsx
+++ b/website/components/ArchitectureDiagram.tsx
@@ -15,47 +15,47 @@ export function ArchitectureDiagram() {
       <div className="space-y-8">
         {/* Horizontal flow: Claude → MCP → r3 */}
         <div className="flex flex-col md:flex-row items-center justify-center gap-4 flex-wrap">
-          <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-gradient-to-r from-purple-900/20 to-purple-800/20 border border-purple-500/20">
-            <Monitor className="h-5 w-5 text-purple-400" />
-            <span className="text-white font-medium">Claude Desktop</span>
+          <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-bg-soft border border-rail">
+            <Monitor className="h-5 w-5 text-ink-dim" />
+            <span className="text-ink font-medium">Claude Desktop</span>
           </div>
 
-          <ArrowRight className="h-5 w-5 text-gray-500 hidden md:block" />
-          <ArrowDown className="h-5 w-5 text-gray-500 md:hidden" />
+          <ArrowRight className="h-5 w-5 text-ink-faint hidden md:block" />
+          <ArrowDown className="h-5 w-5 text-ink-faint md:hidden" />
 
-          <div className="text-sm text-gray-400 bg-gray-900/50 px-4 py-2 rounded border border-gray-800">
+          <div className="text-sm text-ink-dim bg-bg-soft px-4 py-2 rounded border border-rail">
             MCP Protocol
           </div>
 
-          <ArrowRight className="h-5 w-5 text-gray-500 hidden md:block" />
-          <ArrowDown className="h-5 w-5 text-gray-500 md:hidden" />
+          <ArrowRight className="h-5 w-5 text-ink-faint hidden md:block" />
+          <ArrowDown className="h-5 w-5 text-ink-faint md:hidden" />
 
-          <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-gradient-to-r from-blue-900/20 to-blue-800/20 border border-blue-500/20">
-            <Server className="h-5 w-5 text-blue-400" />
-            <span className="text-white font-medium">r3 Server</span>
+          <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-bg-soft border border-rail">
+            <Server className="h-5 w-5 text-ink-dim" />
+            <span className="text-ink font-medium">r3 Server</span>
           </div>
         </div>
 
         {/* Vertical flow: r3 → Redis → Mem0 */}
         <div className="flex justify-center">
           <div className="flex flex-col items-center gap-4">
-            <ArrowDown className="h-5 w-5 text-gray-500" />
+            <ArrowDown className="h-5 w-5 text-ink-faint" />
 
-            <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-gradient-to-r from-red-900/20 to-orange-900/20 border border-red-500/20">
-              <Database className="h-5 w-5 text-red-400" />
+            <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-bg-soft border border-rail">
+              <Database className="h-5 w-5 text-ink-dim" />
               <div className="flex items-center gap-2">
-                <span className="text-white font-medium">Redis</span>
-                <span className="text-xs text-gray-400">(L1 Cache)</span>
+                <span className="text-ink font-medium">Redis</span>
+                <span className="text-xs text-ink-dim">(L1 Cache)</span>
               </div>
             </div>
 
-            <ArrowDown className="h-5 w-5 text-gray-500" />
+            <ArrowDown className="h-5 w-5 text-ink-faint" />
 
-            <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-gradient-to-r from-cyan-900/20 to-teal-900/20 border border-cyan-500/20">
-              <Cloud className="h-5 w-5 text-cyan-400" />
+            <div className="flex items-center gap-3 px-5 py-3 rounded-lg bg-bg-soft border border-rail">
+              <Cloud className="h-5 w-5 text-ink-dim" />
               <div className="flex items-center gap-2">
-                <span className="text-white font-medium">Mem0 Cloud</span>
-                <span className="text-xs text-gray-400">(L2 Storage)</span>
+                <span className="text-ink font-medium">Mem0 Cloud</span>
+                <span className="text-xs text-ink-dim">(L2 Storage)</span>
               </div>
             </div>
           </div>
@@ -63,17 +63,17 @@ export function ArchitectureDiagram() {
 
         {/* Performance metrics */}
         <div className="mt-8 grid grid-cols-3 gap-4 max-w-md mx-auto">
-          <div className="text-center p-3 rounded-lg bg-gray-900/50 border border-gray-800">
-            <div className="text-xl font-light text-green-400">&lt;5ms</div>
-            <div className="text-xs text-gray-500 mt-1">Cache Hit</div>
+          <div className="text-center p-3 rounded-lg bg-bg-soft border border-rail">
+            <div className="text-xl font-light text-ink">&lt;5ms</div>
+            <div className="text-xs text-ink-label mt-1">Cache Hit</div>
           </div>
-          <div className="text-center p-3 rounded-lg bg-gray-900/50 border border-gray-800">
-            <div className="text-xl font-light text-yellow-400">~200ms</div>
-            <div className="text-xs text-gray-500 mt-1">Cache Miss</div>
+          <div className="text-center p-3 rounded-lg bg-bg-soft border border-rail">
+            <div className="text-xl font-light text-ink">~200ms</div>
+            <div className="text-xs text-ink-label mt-1">Cache Miss</div>
           </div>
-          <div className="text-center p-3 rounded-lg bg-gray-900/50 border border-gray-800">
-            <div className="text-xl font-light text-blue-400">~10ms</div>
-            <div className="text-xs text-gray-500 mt-1">First Store</div>
+          <div className="text-center p-3 rounded-lg bg-bg-soft border border-rail">
+            <div className="text-xl font-light text-ink">~10ms</div>
+            <div className="text-xs text-ink-label mt-1">First Store</div>
           </div>
         </div>
       </div>

--- a/website/components/BentoGrid.tsx
+++ b/website/components/BentoGrid.tsx
@@ -28,7 +28,6 @@ interface BentoCardProps {
   icon?: ReactNode;
   className?: string;
   children?: ReactNode;
-  gradient?: string;
   span?: string;
 }
 
@@ -38,15 +37,14 @@ export function BentoCard({
   icon,
   className,
   children,
-  gradient = "from-gray-900 to-gray-800",
   span = "col-span-1",
 }: BentoCardProps) {
   return (
     <motion.div
       className={cn(
-        "group relative overflow-hidden rounded-2xl border border-white/[0.08] p-6 md:p-8",
-        "bg-white/[0.03] transition-all duration-300",
-        "hover:border-white/15 hover:bg-white/[0.05]",
+        "group relative overflow-hidden rounded-2xl border border-rail p-6 md:p-8",
+        "bg-bg-soft transition-all duration-300",
+        "hover:border-rail-strong hover:bg-bg-raise",
         span,
         className,
       )}
@@ -58,17 +56,17 @@ export function BentoCard({
       {/* Content */}
       <div className="relative z-10">
         {icon && (
-          <div className="mb-4 inline-flex rounded-lg bg-white/[0.06] p-2.5">
+          <div className="mb-4 inline-flex rounded-lg bg-bg-raise p-2.5">
             {icon}
           </div>
         )}
 
-        <h3 className="mb-2 text-base font-medium text-white break-words md:text-lg">
+        <h3 className="mb-2 text-base font-medium text-ink break-words md:text-lg">
           {title}
         </h3>
 
         {description && (
-          <p className="text-sm text-[var(--color-grey-400)] break-words leading-relaxed">
+          <p className="text-sm text-ink-dim break-words leading-relaxed">
             {description}
           </p>
         )}

--- a/website/components/BentoGrid.tsx
+++ b/website/components/BentoGrid.tsx
@@ -28,6 +28,8 @@ interface BentoCardProps {
   icon?: ReactNode;
   className?: string;
   children?: ReactNode;
+  /** Deprecated: accepted for compatibility, no longer rendered (flat design). */
+  gradient?: string;
   span?: string;
 }
 

--- a/website/components/CodeBlock.tsx
+++ b/website/components/CodeBlock.tsx
@@ -40,24 +40,24 @@ export function CodeBlock({ children, className, language }: CodeBlockProps) {
   };
 
   return (
-    <div className="relative group my-4 rounded-xl overflow-hidden border border-white/10 bg-black/40">
+    <div className="relative group my-4 rounded-xl overflow-hidden border border-rail bg-bg-soft">
       {/* Header bar */}
-      <div className="flex items-center justify-between px-4 py-2 bg-white/[0.02] border-b border-white/10">
+      <div className="flex items-center justify-between px-4 py-2 bg-bg-raise border-b border-rail">
         <div className="flex items-center gap-2">
-          <Terminal className="h-4 w-4 text-gray-500" />
-          <span className="text-xs text-gray-500 font-mono">
+          <Terminal className="h-4 w-4 text-ink-label" />
+          <span className="text-xs text-ink-label font-mono">
             {getLanguageDisplay(lang)}
           </span>
         </div>
         <button
           onClick={copyToClipboard}
-          className="p-1.5 rounded-md bg-white/5 hover:bg-white/10 transition-colors"
+          className="p-1.5 rounded-md bg-bg-raise hover:bg-rail transition-colors"
           aria-label="Copy code"
         >
           {copied ? (
-            <Check className="h-4 w-4 text-green-400" />
+            <Check className="h-4 w-4 text-ink" />
           ) : (
-            <Copy className="h-4 w-4 text-gray-500 hover:text-gray-200" />
+            <Copy className="h-4 w-4 text-ink-label hover:text-ink" />
           )}
         </button>
       </div>
@@ -70,15 +70,14 @@ export function CodeBlock({ children, className, language }: CodeBlockProps) {
             style={{
               ...style,
               backgroundColor: "transparent",
-              fontFamily:
-                '"SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace',
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
             }}
           >
             <code className="block">
               {tokens.map((line, i) => (
                 <div key={i} {...getLineProps({ line })} className="flex">
                   {/* Line number */}
-                  <span className="inline-block w-8 text-gray-600 text-right select-none flex-shrink-0 pr-4">
+                  <span className="inline-block w-8 text-ink-faint text-right select-none flex-shrink-0 pr-4">
                     {i + 1}
                   </span>
                   {/* Code content */}

--- a/website/components/CodeTabs.tsx
+++ b/website/components/CodeTabs.tsx
@@ -37,7 +37,7 @@ export function CodeTabs({ tabs, children }: CodeTabsProps) {
   }
 
   if (!tabs || tabs.length === 0) {
-    return <div className="text-gray-500">No code tabs available</div>;
+    return <div className="text-ink-faint">No code tabs available</div>;
   }
 
   const copyToClipboard = () => {
@@ -47,9 +47,9 @@ export function CodeTabs({ tabs, children }: CodeTabsProps) {
   };
 
   return (
-    <div className="rounded-lg overflow-hidden border border-white/10 bg-white/[0.01]">
+    <div className="rounded-lg overflow-hidden border border-rail bg-bg-soft">
       {/* Tab Headers */}
-      <div className="flex items-center justify-between border-b border-white/10">
+      <div className="flex items-center justify-between border-b border-rail">
         <div className="flex">
           {tabs.map((tab, index) => (
             <button
@@ -57,8 +57,8 @@ export function CodeTabs({ tabs, children }: CodeTabsProps) {
               onClick={() => setActiveTab(index)}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
                 activeTab === index
-                  ? "text-white bg-white/5 border-b-2 border-blue-400"
-                  : "text-gray-400 hover:text-white"
+                  ? "text-ink bg-bg-raise border-b-2 border-accent"
+                  : "text-ink-dim hover:text-ink"
               }`}
             >
               {tab.label}
@@ -67,7 +67,7 @@ export function CodeTabs({ tabs, children }: CodeTabsProps) {
         </div>
         <button
           onClick={copyToClipboard}
-          className="flex items-center gap-1 px-3 py-2 text-xs text-gray-500 hover:text-white transition-colors"
+          className="flex items-center gap-1 px-3 py-2 text-xs text-ink-label hover:text-ink transition-colors"
         >
           {copied ? (
             <>
@@ -85,7 +85,7 @@ export function CodeTabs({ tabs, children }: CodeTabsProps) {
 
       {/* Code Content */}
       <pre className="p-4 overflow-x-auto">
-        <code className="text-sm text-gray-300 font-mono">
+        <code className="text-sm text-ink font-mono">
           {tabs[activeTab].code}
         </code>
       </pre>

--- a/website/components/DocsHeader.tsx
+++ b/website/components/DocsHeader.tsx
@@ -9,14 +9,14 @@ export function DocsHeader() {
   const [showVersionDropdown, setShowVersionDropdown] = useState(false);
 
   return (
-    <div className="sticky top-20 z-40 bg-black/80 backdrop-blur-xl border-b border-[var(--glass-border)]">
+    <div className="sticky top-20 z-40 bg-bg/80 backdrop-blur-xl border-b border-rail">
       <div className="mx-auto max-w-[1600px] px-6 lg:px-8">
         <div className="flex items-center justify-between h-14">
           {/* Left: Breadcrumb */}
           <div className="flex items-center gap-2 text-sm">
-            <span className="text-[var(--color-grey-400)]">Docs</span>
-            <span className="text-[var(--color-grey-400)]">/</span>
-            <span className="text-white font-medium">Getting Started</span>
+            <span className="text-ink-dim">Docs</span>
+            <span className="text-ink-dim">/</span>
+            <span className="text-ink font-medium">Getting Started</span>
           </div>
 
           {/* Right: Actions */}
@@ -24,17 +24,17 @@ export function DocsHeader() {
             {/* Search */}
             <button
               onClick={() => setShowSearch(true)}
-              className="flex items-center gap-2 px-3 py-1.5 bg-[var(--glass-bg)] hover:bg-white/10 border border-[var(--glass-border)] rounded-lg transition-colors sm:w-48"
+              className="flex items-center gap-2 px-3 py-1.5 bg-bg-soft hover:bg-bg-raise border border-rail rounded-lg transition-colors sm:w-48"
             >
-              <Search className="h-4 w-4 text-[var(--color-grey-400)]" />
-              <span className="hidden sm:inline text-sm text-[var(--color-grey-400)]">
+              <Search className="h-4 w-4 text-ink-dim" />
+              <span className="hidden sm:inline text-sm text-ink-dim">
                 Search
               </span>
               <div className="hidden sm:flex items-center gap-1 ml-4 sm:ml-8">
-                <kbd className="px-1.5 py-0.5 text-xs bg-white/10 rounded border border-white/20">
+                <kbd className="px-1.5 py-0.5 text-xs bg-bg-raise rounded border border-rail-strong">
                   ⌘
                 </kbd>
-                <kbd className="px-1.5 py-0.5 text-xs bg-white/10 rounded border border-white/20">
+                <kbd className="px-1.5 py-0.5 text-xs bg-bg-raise rounded border border-rail-strong">
                   K
                 </kbd>
               </div>
@@ -44,21 +44,21 @@ export function DocsHeader() {
             <div className="relative">
               <button
                 onClick={() => setShowVersionDropdown(!showVersionDropdown)}
-                className="flex items-center gap-2 px-3 py-1.5 bg-[var(--glass-bg)] hover:bg-white/10 border border-[var(--glass-border)] rounded-lg transition-colors"
+                className="flex items-center gap-2 px-3 py-1.5 bg-bg-soft hover:bg-bg-raise border border-rail rounded-lg transition-colors"
               >
-                <span className="text-sm text-white">
+                <span className="text-sm text-ink">
                   {versionConfig.current}
                 </span>
-                <ChevronDown className="h-3 w-3 text-[var(--color-grey-400)]" />
+                <ChevronDown className="h-3 w-3 text-ink-dim" />
               </button>
 
               {showVersionDropdown && (
-                <div className="absolute right-0 mt-2 w-48 bg-gray-900 border border-[var(--glass-border)] rounded-lg shadow-xl overflow-hidden">
+                <div className="absolute right-0 mt-2 w-48 bg-bg-raise border border-rail-strong rounded-lg overflow-hidden">
                   {versionConfig.versions.map((version) => (
                     <a
                       key={version.version}
                       href={version.path}
-                      className="block px-4 py-2 text-sm text-gray-300 hover:bg-[var(--glass-bg)] hover:text-white transition-colors"
+                      className="block px-4 py-2 text-sm text-ink-dim hover:bg-rail hover:text-ink transition-colors"
                     >
                       {version.label}
                     </a>
@@ -70,7 +70,7 @@ export function DocsHeader() {
             {/* API Reference */}
             <a
               href="/docs/api-reference"
-              className="hidden sm:inline-flex px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 text-blue-400 text-sm font-medium rounded-lg transition-colors"
+              className="hidden sm:inline-flex px-3 py-1.5 bg-bg-soft hover:bg-bg-raise border border-rail-strong text-ink text-sm font-medium rounded-lg transition-colors"
             >
               API Reference
             </a>
@@ -81,27 +81,27 @@ export function DocsHeader() {
       {/* Search Modal */}
       {showSearch && (
         <div
-          className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+          className="fixed inset-0 z-50 bg-bg/80"
           onClick={() => setShowSearch(false)}
         >
           <div className="fixed inset-x-0 top-20 mx-auto max-w-2xl p-4">
             <div
-              className="bg-gray-900 border border-[var(--glass-border)] rounded-xl shadow-2xl overflow-hidden"
+              className="bg-bg-raise border border-rail-strong rounded-xl overflow-hidden"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--glass-border)]">
-                <Search className="h-5 w-5 text-[var(--color-grey-400)]" />
+              <div className="flex items-center gap-3 px-4 py-3 border-b border-rail">
+                <Search className="h-5 w-5 text-ink-dim" />
                 <input
                   type="text"
                   placeholder="Search documentation..."
-                  className="flex-1 bg-transparent text-white placeholder-gray-500 focus:outline-none"
+                  className="flex-1 bg-transparent text-ink placeholder:text-ink-faint focus:outline-none"
                   autoFocus
                 />
                 <button
                   onClick={() => setShowSearch(false)}
-                  className="text-[var(--color-grey-400)] hover:text-white"
+                  className="text-ink-dim hover:text-ink"
                 >
-                  <kbd className="px-2 py-1 text-xs bg-white/10 rounded border border-white/20">
+                  <kbd className="px-2 py-1 text-xs bg-bg-raise rounded border border-rail-strong">
                     ESC
                   </kbd>
                 </button>
@@ -112,56 +112,56 @@ export function DocsHeader() {
                 <div className="space-y-1">
                   <a
                     href="/docs/getting-started/quickstart"
-                    className="block px-3 py-2 rounded-lg hover:bg-[var(--glass-bg)] transition-colors"
+                    className="block px-3 py-2 rounded-lg hover:bg-rail transition-colors"
                   >
-                    <div className="text-sm font-medium text-white">
+                    <div className="text-sm font-medium text-ink">
                       Quick Start
                     </div>
-                    <div className="text-xs text-[var(--color-grey-400)]">
+                    <div className="text-xs text-ink-dim">
                       Get up and running in 5 minutes
                     </div>
                   </a>
                   <a
                     href="/docs/api/client"
-                    className="block px-3 py-2 rounded-lg hover:bg-[var(--glass-bg)] transition-colors"
+                    className="block px-3 py-2 rounded-lg hover:bg-rail transition-colors"
                   >
-                    <div className="text-sm font-medium text-white">
+                    <div className="text-sm font-medium text-ink">
                       Client API
                     </div>
-                    <div className="text-xs text-[var(--color-grey-400)]">
+                    <div className="text-xs text-ink-dim">
                       Complete API reference for the r3 client
                     </div>
                   </a>
                   <a
                     href="/docs/examples/chatbot-memory"
-                    className="block px-3 py-2 rounded-lg hover:bg-[var(--glass-bg)] transition-colors"
+                    className="block px-3 py-2 rounded-lg hover:bg-rail transition-colors"
                   >
-                    <div className="text-sm font-medium text-white">
+                    <div className="text-sm font-medium text-ink">
                       Chatbot with Memory
                     </div>
-                    <div className="text-xs text-[var(--color-grey-400)]">
+                    <div className="text-xs text-ink-dim">
                       Build an intelligent chatbot
                     </div>
                   </a>
                 </div>
               </div>
 
-              <div className="px-4 py-2 border-t border-[var(--glass-border)] bg-white/[0.02]">
-                <div className="flex items-center gap-4 text-xs text-[var(--color-grey-400)]">
+              <div className="px-4 py-2 border-t border-rail bg-bg-soft">
+                <div className="flex items-center gap-4 text-xs text-ink-dim">
                   <span className="flex items-center gap-1">
-                    <kbd className="px-1 py-0.5 bg-white/10 rounded border border-white/20">
+                    <kbd className="px-1 py-0.5 bg-bg-raise rounded border border-rail-strong">
                       ↑↓
                     </kbd>
                     Navigate
                   </span>
                   <span className="flex items-center gap-1">
-                    <kbd className="px-1 py-0.5 bg-white/10 rounded border border-white/20">
+                    <kbd className="px-1 py-0.5 bg-bg-raise rounded border border-rail-strong">
                       ↵
                     </kbd>
                     Select
                   </span>
                   <span className="flex items-center gap-1">
-                    <kbd className="px-1 py-0.5 bg-white/10 rounded border border-white/20">
+                    <kbd className="px-1 py-0.5 bg-bg-raise rounded border border-rail-strong">
                       ESC
                     </kbd>
                     Close

--- a/website/components/DocsSidebar.tsx
+++ b/website/components/DocsSidebar.tsx
@@ -30,13 +30,13 @@ export function DocsSidebar() {
     <nav className="space-y-6">
       {/* Search */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--color-grey-400)]" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-ink-dim" />
         <input
           type="text"
           placeholder="Search docs..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full pl-10 pr-3 py-2 bg-[var(--glass-bg)] border border-[var(--glass-border)] rounded-lg text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-transparent"
+          className="w-full pl-10 pr-3 py-2 bg-bg-soft border border-rail rounded-lg text-sm text-ink placeholder:text-ink-faint focus:outline-none focus:ring-2 focus:ring-rail-strong focus:border-transparent"
         />
       </div>
 
@@ -52,7 +52,7 @@ export function DocsSidebar() {
             <div key={section.title}>
               <button
                 onClick={() => toggleSection(section.title)}
-                className="flex items-center justify-between w-full px-2 py-1.5 text-sm font-medium text-[var(--color-grey-400)] hover:text-white transition-colors"
+                className="flex items-center justify-between w-full px-2 py-1.5 text-sm font-medium text-ink-label hover:text-ink transition-colors"
               >
                 <span>{section.title}</span>
                 <ChevronRight
@@ -75,25 +75,14 @@ export function DocsSidebar() {
                           group flex items-center justify-between px-3 py-1.5 text-sm rounded-lg transition-all
                           ${
                             isActive
-                              ? "bg-white/10 text-white font-medium"
-                              : "text-[var(--color-grey-400)] hover:text-white hover:bg-[var(--glass-bg)]"
+                              ? "bg-bg-raise text-ink font-medium"
+                              : "text-ink-dim hover:text-ink hover:bg-bg-soft"
                           }
                         `}
                       >
                         <span>{item.title}</span>
                         {item.badge && (
-                          <span
-                            className={`
-                            px-1.5 py-0.5 text-xs rounded-full font-medium
-                            ${
-                              item.badge === "New"
-                                ? "bg-green-500/20 text-green-400"
-                                : item.badge === "Pro"
-                                  ? "bg-purple-500/20 text-purple-400"
-                                  : "bg-yellow-500/20 text-yellow-400"
-                            }
-                          `}
-                          >
+                          <span className="px-1.5 py-0.5 text-xs rounded-full font-medium bg-bg-raise border border-rail text-ink-dim">
                             {item.badge}
                           </span>
                         )}
@@ -108,11 +97,11 @@ export function DocsSidebar() {
       </div>
 
       {/* Quick Links */}
-      <div className="pt-6 border-t border-[var(--glass-border)]">
+      <div className="pt-6 border-t border-rail">
         <div className="space-y-2">
           <Link
             href="https://github.com/n3wth/r3"
-            className="flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-grey-400)] hover:text-white transition-colors"
+            className="flex items-center gap-2 px-3 py-2 text-sm text-ink-dim hover:text-ink transition-colors"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/website/components/Grid.tsx
+++ b/website/components/Grid.tsx
@@ -46,7 +46,7 @@ export function Section({
     white: "bg-white",
     gray: "bg-gray-50",
     gradient: "bg-gradient-to-b from-white to-gray-50",
-    dark: "bg-black",
+    dark: "bg-bg",
   }[background];
 
   return (

--- a/website/components/LogoEffectSlideshow.tsx
+++ b/website/components/LogoEffectSlideshow.tsx
@@ -1,103 +1,19 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { motion, AnimatePresence } from "framer-motion";
 
+/* Flat wordmark — decorative overlay effects removed.
+   source of truth: @n3wth/ui/theme */
 export function LogoEffectSlideshow() {
-  const [currentEffect, setCurrentEffect] = useState(0);
-
-  // Define just the overlay effects (logo text stays constant)
-  const effects = [
-    // No effect (clean)
-    {
-      name: "clean",
-      overlay: null,
-    },
-    // Gradient Glow Pulse
-    {
-      name: "gradient-glow",
-      overlay: (
-        <div
-          className="absolute inset-0 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 blur-xl opacity-30 animate-pulse pointer-events-none"
-          style={{ animationDuration: "2s" }}
-        ></div>
-      ),
-    },
-    // Quantum Dots
-    {
-      name: "quantum-dots",
-      overlay: (
-        <>
-          <div className="absolute top-0 left-1/4 w-1 h-1 bg-blue-400/60 rounded-full animate-quantum-1 pointer-events-none"></div>
-          <div className="absolute bottom-0 right-1/4 w-1 h-1 bg-purple-400/60 rounded-full animate-quantum-2 pointer-events-none"></div>
-          <div className="absolute top-1/2 left-0 w-1 h-1 bg-cyan-400/60 rounded-full animate-quantum-3 pointer-events-none"></div>
-          <div className="absolute top-1/2 right-0 w-1 h-1 bg-pink-400/60 rounded-full animate-quantum-4 pointer-events-none"></div>
-        </>
-      ),
-    },
-    // Orbiting Particles
-    {
-      name: "orbiting",
-      overlay: (
-        <>
-          <div className="absolute -top-1 left-1/4 w-1 h-1 bg-blue-400 rounded-full animate-orbit-1 pointer-events-none"></div>
-          <div className="absolute top-1/2 -right-1 w-1 h-1 bg-purple-400 rounded-full animate-orbit-2 pointer-events-none"></div>
-          <div className="absolute -bottom-1 left-1/3 w-1 h-1 bg-pink-400 rounded-full animate-orbit-3 pointer-events-none"></div>
-        </>
-      ),
-    },
-    // Subtle Morphing Background
-    {
-      name: "morphing",
-      overlay: (
-        <div className="absolute -inset-2 bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-lg opacity-50 blur-md animate-subtle-morph pointer-events-none"></div>
-      ),
-    },
-    // Breathing Glow
-    {
-      name: "breathing",
-      overlay: (
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-400/20 via-purple-400/20 to-pink-400/20 blur-lg rounded-lg animate-breathe pointer-events-none"></div>
-      ),
-    },
-  ];
-
-  // Cycle through effects every 4 seconds
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentEffect((prev) => (prev + 1) % effects.length);
-    }, 4000);
-
-    return () => clearInterval(interval);
-  }, [effects.length]);
-
   return (
     <Link
       href="/"
-      className="relative inline-flex items-center text-3xl font-semibold text-white"
+      className="relative inline-flex items-center text-3xl font-semibold text-ink"
       style={{ fontFamily: "var(--font-brand)" }}
     >
-      {/* The actual logo text (always visible) */}
       <span className="relative z-10">
         r<span className="relative -top-[0.15em] text-2xl">3</span>
       </span>
-
-      {/* Animated overlay effects with fade transitions */}
-      <AnimatePresence mode="wait">
-        {effects[currentEffect].overlay && (
-          <motion.div
-            key={effects[currentEffect].name}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.8, ease: "easeInOut" }}
-            className="absolute inset-0"
-          >
-            {effects[currentEffect].overlay}
-          </motion.div>
-        )}
-      </AnimatePresence>
     </Link>
   );
 }

--- a/website/components/MDXComponents.tsx
+++ b/website/components/MDXComponents.tsx
@@ -22,7 +22,7 @@ export const MDXComponents = {
     if (!className) {
       return (
         <code
-          className="px-1.5 py-0.5 rounded bg-gray-800 text-gray-300 text-sm font-mono"
+          className="px-1.5 py-0.5 rounded bg-bg-raise text-ink text-sm font-mono"
           {...props}
         >
           {children}

--- a/website/components/MemoryComparison.tsx
+++ b/website/components/MemoryComparison.tsx
@@ -73,26 +73,26 @@ export function MemoryComparison() {
     : conversations.without;
 
   return (
-    <section className="py-32 border-t border-white/5 relative overflow-hidden">
+    <section className="py-32 border-t border-rail relative overflow-hidden">
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <div className="text-center mb-12">
-          <h2 className="text-3xl sm:text-4xl font-normal text-white mb-4">
+          <h2 className="text-3xl sm:text-4xl font-normal text-ink mb-4">
             Same conversation, different experience
           </h2>
-          <p className="text-lg text-gray-400 max-w-2xl mx-auto">
+          <p className="text-lg text-ink-dim max-w-2xl mx-auto">
             Watch how the same project evolves over three days
           </p>
         </div>
 
         {/* Toggle Switch */}
         <div className="flex justify-center mb-12">
-          <div className="inline-flex p-1 bg-gray-900/50 rounded-lg border border-white/10">
+          <div className="inline-flex p-1 bg-bg-soft rounded-lg border border-rail">
             <button
               onClick={() => setIsWithMemory(false)}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
                 !isWithMemory
-                  ? "bg-gray-800 text-white"
-                  : "text-gray-400 hover:text-white"
+                  ? "bg-bg-raise text-ink"
+                  : "text-ink-dim hover:text-ink"
               }`}
             >
               Without r3
@@ -101,8 +101,8 @@ export function MemoryComparison() {
               onClick={() => setIsWithMemory(true)}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
                 isWithMemory
-                  ? "bg-emerald-900/30 text-emerald-400"
-                  : "text-gray-400 hover:text-white"
+                  ? "bg-bg-raise text-ink"
+                  : "text-ink-dim hover:text-ink"
               }`}
             >
               With r3
@@ -112,29 +112,29 @@ export function MemoryComparison() {
 
         {/* Chat Interface */}
         <div className="max-w-3xl mx-auto">
-          <div className="bg-gray-900/30 backdrop-blur-sm rounded-2xl border border-white/10 overflow-hidden">
+          <div className="bg-bg-soft rounded-2xl border border-rail overflow-hidden">
             {/* Header */}
-            <div className="px-6 py-4 border-b border-white/10 flex items-center justify-between">
+            <div className="px-6 py-4 border-b border-rail flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div
-                  className={`w-2 h-2 rounded-full ${isWithMemory ? "bg-emerald-400" : "bg-gray-400"}`}
+                  className={`w-2 h-2 rounded-full ${isWithMemory ? "bg-accent" : "bg-ink-faint"}`}
                 />
-                <span className="text-sm font-medium text-white">
+                <span className="text-sm font-medium text-ink">
                   {currentConversations[currentDay].day}
                 </span>
               </div>
               <div className="flex items-center gap-2">
                 {isWithMemory ? (
                   <>
-                    <Brain className="h-4 w-4 text-emerald-400" />
-                    <span className="text-xs text-emerald-400">
+                    <Brain className="h-4 w-4 text-ink" />
+                    <span className="text-xs text-ink">
                       Memory active
                     </span>
                   </>
                 ) : (
                   <>
-                    <RotateCcw className="h-4 w-4 text-gray-400" />
-                    <span className="text-xs text-gray-400">No memory</span>
+                    <RotateCcw className="h-4 w-4 text-ink-dim" />
+                    <span className="text-xs text-ink-dim">No memory</span>
                   </>
                 )}
               </div>
@@ -154,12 +154,12 @@ export function MemoryComparison() {
                   {/* User Message */}
                   <div className="flex justify-end">
                     <div className="max-w-[80%]">
-                      <div className="bg-blue-600/20 border border-blue-500/30 rounded-2xl rounded-tr-sm px-4 py-3">
-                        <p className="text-sm text-gray-200">
+                      <div className="bg-bg-raise border border-rail-strong rounded-2xl rounded-tr-sm px-4 py-3">
+                        <p className="text-sm text-ink">
                           {currentConversations[currentDay].user}
                         </p>
                       </div>
-                      <p className="text-xs text-gray-500 mt-1 text-right">
+                      <p className="text-xs text-ink-label mt-1 text-right">
                         You
                       </p>
                     </div>
@@ -168,12 +168,12 @@ export function MemoryComparison() {
                   {/* AI Response */}
                   <div className="flex justify-start">
                     <div className="max-w-[80%]">
-                      <div className="bg-gray-800/50 border border-white/10 rounded-2xl rounded-tl-sm px-4 py-3">
-                        <p className="text-sm text-gray-200">
+                      <div className="bg-bg-raise border border-rail rounded-2xl rounded-tl-sm px-4 py-3">
+                        <p className="text-sm text-ink">
                           {currentConversations[currentDay].ai}
                         </p>
                       </div>
-                      <p className="text-xs text-gray-500 mt-1">AI Assistant</p>
+                      <p className="text-xs text-ink-label mt-1">AI Assistant</p>
                     </div>
                   </div>
                 </motion.div>
@@ -188,8 +188,8 @@ export function MemoryComparison() {
                     key={i}
                     className={`h-1 rounded-full transition-all duration-300 ${
                       i === currentDay
-                        ? `w-8 ${isWithMemory ? "bg-emerald-400" : "bg-gray-400"}`
-                        : "w-1 bg-gray-600"
+                        ? `w-8 ${isWithMemory ? "bg-accent" : "bg-ink-dim"}`
+                        : "w-1 bg-ink-faint"
                     }`}
                   />
                 ))}
@@ -199,7 +199,7 @@ export function MemoryComparison() {
 
           {/* Bottom Caption */}
           <div className="mt-8 text-center">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-ink-dim">
               {isWithMemory
                 ? "Context builds naturally over time"
                 : "Every conversation starts from scratch"}

--- a/website/components/MemoryVisualization.tsx
+++ b/website/components/MemoryVisualization.tsx
@@ -37,13 +37,14 @@ interface Particle {
   delay: number;
 }
 
+/* source of truth: @n3wth/ui/theme — monochrome ink scale */
 const memoryTypes = {
-  user: { color: "#8b5cf6", label: "User Context" },
-  project: { color: "#3b82f6", label: "Project Memory" },
-  code: { color: "#06b6d4", label: "Code Patterns" },
-  api: { color: "#10b981", label: "API Keys" },
-  knowledge: { color: "#f59e0b", label: "Knowledge Base" },
-  workflow: { color: "#ec4899", label: "Workflows" },
+  user: { color: "#f2f3f5", label: "User Context" },
+  project: { color: "#d4d6da", label: "Project Memory" },
+  code: { color: "#9aa0a8", label: "Code Patterns" },
+  api: { color: "#f2f3f5", label: "API Keys" },
+  knowledge: { color: "#d4d6da", label: "Knowledge Base" },
+  workflow: { color: "#9aa0a8", label: "Workflows" },
 };
 
 export function MemoryVisualization() {
@@ -185,39 +186,8 @@ export function MemoryVisualization() {
 
   return (
     <div ref={containerRef} className="absolute inset-0 overflow-hidden">
-      {/* Background gradient */}
-      <div className="absolute inset-0">
-        <div className="absolute inset-0 bg-gradient-to-br from-purple-900/10 via-transparent to-blue-900/10" />
-        <div className="absolute inset-0 bg-gradient-to-tl from-cyan-900/5 via-transparent to-pink-900/5" />
-        {/* Outer edge brightness */}
-        <div className="absolute inset-0 bg-gradient-radial from-transparent via-transparent to-white/[0.02]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_0%,transparent_50%,rgba(139,92,246,0.05)_90%,rgba(139,92,246,0.08)_100%)]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,transparent_0%,transparent_40%,rgba(59,130,246,0.06)_100%)]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,transparent_0%,transparent_40%,rgba(6,182,212,0.06)_100%)]" />
-      </div>
-
       {/* Connections */}
       <svg className="absolute inset-0 w-full h-full pointer-events-none">
-        <defs>
-          <linearGradient
-            id="connectionGradient"
-            x1="0%"
-            y1="0%"
-            x2="100%"
-            y2="100%"
-          >
-            <stop offset="0%" stopColor="rgba(139, 92, 246, 0.4)" />
-            <stop offset="50%" stopColor="rgba(59, 130, 246, 0.4)" />
-            <stop offset="100%" stopColor="rgba(6, 182, 212, 0.4)" />
-          </linearGradient>
-          <filter id="glow">
-            <feGaussianBlur stdDeviation="2" result="coloredBlur" />
-            <feMerge>
-              <feMergeNode in="coloredBlur" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
-        </defs>
         {connections.map((connection) => {
           const sourceNode = nodes.find((n) => n.id === connection.source);
           const targetNode = nodes.find((n) => n.id === connection.target);
@@ -236,16 +206,15 @@ export function MemoryVisualization() {
                 stroke="rgba(255, 255, 255, 0.08)"
                 strokeWidth="0.5"
               />
-              {/* Active glow line */}
+              {/* Active line */}
               {isActive && (
                 <motion.line
                   x1={`${sourceNode.x}%`}
                   y1={`${sourceNode.y}%`}
                   x2={`${targetNode.x}%`}
                   y2={`${targetNode.y}%`}
-                  stroke="url(#connectionGradient)"
+                  stroke="rgba(255, 255, 255, 0.32)"
                   strokeWidth="1.5"
-                  filter="url(#glow)"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 0.8 }}
                   exit={{ opacity: 0 }}
@@ -259,10 +228,9 @@ export function MemoryVisualization() {
                     r={isActive ? "3" : "2"}
                     fill={
                       isActive
-                        ? "rgba(139, 92, 246, 1)"
-                        : "rgba(139, 92, 246, 0.6)"
+                        ? "rgba(242, 243, 245, 1)"
+                        : "rgba(242, 243, 245, 0.6)"
                     }
-                    filter={isActive ? "url(#glow)" : undefined}
                   >
                     <animateMotion
                       dur="3s"
@@ -287,10 +255,9 @@ export function MemoryVisualization() {
                     r={isActive ? "2" : "1.5"}
                     fill={
                       isActive
-                        ? "rgba(59, 130, 246, 1)"
-                        : "rgba(59, 130, 246, 0.5)"
+                        ? "rgba(212, 214, 218, 1)"
+                        : "rgba(212, 214, 218, 0.5)"
                     }
-                    filter={isActive ? "url(#glow)" : undefined}
                   >
                     <animateMotion
                       dur="3s"
@@ -311,10 +278,9 @@ export function MemoryVisualization() {
                     r={isActive ? "1.5" : "1"}
                     fill={
                       isActive
-                        ? "rgba(6, 182, 212, 1)"
-                        : "rgba(6, 182, 212, 0.4)"
+                        ? "rgba(154, 160, 168, 1)"
+                        : "rgba(154, 160, 168, 0.4)"
                     }
-                    filter={isActive ? "url(#glow)" : undefined}
                   >
                     <animateMotion
                       dur="3s"
@@ -409,8 +375,7 @@ export function MemoryVisualization() {
               <div
                 className="absolute inset-0 rounded-full"
                 style={{
-                  background: `radial-gradient(circle, ${node.color}ee, ${node.color}66)`,
-                  boxShadow: `0 0 ${isHighlighted ? 30 : 10}px ${node.color}44`,
+                  background: `${node.color}${isHighlighted ? "ee" : "aa"}`,
                 }}
               />
 
@@ -467,7 +432,6 @@ export function MemoryVisualization() {
             backgroundColor: `rgba(255, 255, 255, ${particle.opacity})`,
             left: `${particle.left}%`,
             top: `${particle.top}%`,
-            filter: "blur(0.5px)",
           }}
           animate={{
             y: -200,
@@ -482,18 +446,6 @@ export function MemoryVisualization() {
           }}
         />
       ))}
-
-      {/* Central glow effect */}
-      <div
-        className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-        style={{
-          width: "60%",
-          height: "60%",
-          background:
-            "radial-gradient(circle, rgba(147, 51, 234, 0.1) 0%, transparent 70%)",
-          filter: "blur(40px)",
-        }}
-      />
     </div>
   );
 }

--- a/website/components/ScrollReveal.tsx
+++ b/website/components/ScrollReveal.tsx
@@ -3,8 +3,12 @@
 import { useRef, useEffect, type ReactNode } from "react";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { CustomEase } from "gsap/CustomEase";
 
-gsap.registerPlugin(ScrollTrigger);
+gsap.registerPlugin(ScrollTrigger, CustomEase);
+
+/* source of truth: @n3wth/ui/theme --ease */
+const EASE = CustomEase.create("n3wthEase", "0.16,1,0.3,1");
 
 interface ScrollRevealProps {
   children: ReactNode;
@@ -39,7 +43,7 @@ export function ScrollReveal({
           y: 0,
           duration,
           delay,
-          ease: "power3.out",
+          ease: EASE,
         });
       },
       once: true,
@@ -86,7 +90,7 @@ export function StaggerReveal({
           y: 0,
           duration: 0.6,
           stagger,
-          ease: "power3.out",
+          ease: EASE,
         });
       },
       once: true,

--- a/website/components/TableOfContents.tsx
+++ b/website/components/TableOfContents.tsx
@@ -76,7 +76,7 @@ export function TableOfContents() {
 
   return (
     <div className="space-y-3">
-      <h4 className="text-sm font-medium text-white">On this page</h4>
+      <h4 className="text-sm font-medium text-ink">On this page</h4>
       <nav className="space-y-1">
         {headings.map((heading) => (
           <a
@@ -87,8 +87,8 @@ export function TableOfContents() {
               ${heading.level === 3 ? "ml-4" : ""}
               ${
                 activeId === heading.id
-                  ? "text-blue-400 font-medium"
-                  : "text-gray-500 hover:text-gray-300"
+                  ? "text-ink font-medium"
+                  : "text-ink-faint hover:text-ink-dim"
               }
             `}
             onClick={(e) => {

--- a/website/components/TerminalDemo.tsx
+++ b/website/components/TerminalDemo.tsx
@@ -15,53 +15,53 @@ const demos = [
       {
         type: "animated",
         text: "Claude Code v1.0.5 • Model: Claude 3.5 Sonnet",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 1500,
       },
       {
         type: "animated",
         text: "✓ MCP server 'r3' connected (hybrid memory active)",
-        className: "text-green-500",
+        className: "text-ink",
         delay: 2000,
       },
       {
         type: "animated",
         text: "You: Remember I prefer React with TypeScript, Tailwind CSS, and Vitest for testing",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 3000,
         userText: true,
       },
       {
         type: "animated",
         text: "Claude: I'll remember your development stack preferences.",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 4500,
         assistantText: true,
       },
       {
         type: "animated",
         text: "[Memory stored: 3ms • Priority: high • TTL: persistent]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 5000,
       },
       {
         type: "animated",
         text: "You: Create a new component",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 6000,
         userText: true,
       },
       {
         type: "animated",
         text: "Claude: I'll create a TypeScript React component with Tailwind styling...",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 7000,
         assistantText: true,
       },
       {
         type: "animated",
         text: "[Memory retrieved: 2ms from L1 cache]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 7500,
       },
     ],
@@ -77,19 +77,19 @@ const demos = [
       {
         type: "animated",
         text: "Gemini CLI with r3 context • Model: Gemini 1.5 Pro",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 1500,
       },
       {
         type: "animated",
         text: "✓ Saved to r3 and GEMINI.md",
-        className: "text-green-500",
+        className: "text-ink",
         delay: 2500,
       },
       {
         type: "animated",
         text: "[Memory synced: L1 cache + L2 persistence]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 3000,
       },
       {
@@ -100,37 +100,37 @@ const demos = [
       {
         type: "animated",
         text: "📚 Retrieving context from r3...",
-        className: "text-blue-400",
+        className: "text-ink-dim",
         delay: 5500,
       },
       {
         type: "animated",
         text: "Based on your setup, you use r3 which combines:",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 6500,
       },
       {
         type: "animated",
         text: "• L1 Cache: Redis (sub-5ms responses)",
-        className: "text-gray-300",
+        className: "text-ink-dim",
         delay: 7000,
       },
       {
         type: "animated",
         text: "• L2 Storage: Cloud persistence",
-        className: "text-gray-300",
+        className: "text-ink-dim",
         delay: 7500,
       },
       {
         type: "animated",
         text: "• Smart routing with cache optimization",
-        className: "text-gray-300",
+        className: "text-ink-dim",
         delay: 8000,
       },
       {
         type: "animated",
         text: "[Context enhanced with 3 relevant memories]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 8500,
       },
     ],
@@ -146,13 +146,13 @@ const demos = [
       {
         type: "animated",
         text: "◐ Installing MCP server...",
-        className: "text-blue-500",
+        className: "text-ink-dim",
         delay: 1500,
       },
       {
         type: "animated",
         text: "✓ MCP server 'r3' added to claude_config.json",
-        className: "text-green-500",
+        className: "text-ink",
         delay: 2500,
       },
       {
@@ -163,41 +163,41 @@ const demos = [
       {
         type: "animated",
         text: "You: Remember our API uses GraphQL with Apollo Client",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 5000,
         userText: true,
       },
       {
         type: "animated",
         text: "Claude: Noted. I'll use GraphQL queries with Apollo Client for API calls.",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 6500,
         assistantText: true,
       },
       {
         type: "animated",
         text: "[Memory stored: Project-specific context saved]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 7000,
       },
       {
         type: "animated",
         text: "You: Add user authentication",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 8000,
         userText: true,
       },
       {
         type: "animated",
         text: "Claude: I'll implement auth using GraphQL mutations with Apollo Client...",
-        className: "text-gray-400",
+        className: "text-ink-dim",
         delay: 9000,
         assistantText: true,
       },
       {
         type: "animated",
         text: "[Retrieved 5 related memories about your auth patterns]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 9500,
       },
     ],
@@ -209,31 +209,31 @@ const demos = [
       {
         type: "animated",
         text: "Running 4 parallel checks with r3 context...",
-        className: "text-blue-400",
+        className: "text-ink-dim",
         delay: 1500,
       },
       {
         type: "animated",
         text: "✓ Authentication: JWT with refresh tokens",
-        className: "text-green-400",
+        className: "text-ink",
         delay: 2500,
       },
       {
         type: "animated",
         text: "✓ Database: PostgreSQL with Prisma ORM",
-        className: "text-green-400",
+        className: "text-ink",
         delay: 3000,
       },
       {
         type: "animated",
         text: "✓ Testing: 87% coverage with Vitest",
-        className: "text-green-400",
+        className: "text-ink",
         delay: 3500,
       },
       {
         type: "animated",
         text: "✓ Performance: Core Web Vitals passing",
-        className: "text-green-400",
+        className: "text-ink",
         delay: 4000,
       },
       {
@@ -244,25 +244,25 @@ const demos = [
       {
         type: "animated",
         text: "Analyzing with r3-enhanced context...",
-        className: "text-blue-400",
+        className: "text-ink-dim",
         delay: 6500,
       },
       {
         type: "animated",
         text: "Project A: OAuth 2.0 with social providers",
-        className: "text-gray-300",
+        className: "text-ink-dim",
         delay: 7500,
       },
       {
         type: "animated",
         text: "Project B: Magic link authentication",
-        className: "text-gray-300",
+        className: "text-ink-dim",
         delay: 8000,
       },
       {
         type: "animated",
         text: "[Analysis enhanced with your auth preference history]",
-        className: "text-gray-500 text-xs",
+        className: "text-ink-faint text-xs",
         delay: 8500,
       },
     ],
@@ -295,7 +295,7 @@ export function TerminalDemo() {
   if (!mounted) {
     return (
       <div className="w-full h-auto min-h-[400px] sm:h-[500px] flex items-center justify-center">
-        <div className="text-gray-500">Loading terminal...</div>
+        <div className="text-ink-faint">Loading terminal...</div>
       </div>
     );
   }
@@ -303,7 +303,7 @@ export function TerminalDemo() {
   return (
     <div className="w-full h-auto min-h-[400px] sm:h-[500px] flex flex-col items-center justify-center p-2 sm:p-4">
       <div className="text-center mb-4">
-        <h3 className="text-lg font-semibold text-white mb-1">{demo.title}</h3>
+        <h3 className="text-lg font-semibold text-ink mb-1">{demo.title}</h3>
         <div className="flex gap-2 justify-center">
           {demos.map((_, index) => (
             <button
@@ -314,8 +314,8 @@ export function TerminalDemo() {
               }}
               className={`w-2 h-2 rounded-full transition-all ${
                 index === currentDemo
-                  ? "bg-blue-500 w-8"
-                  : "bg-gray-600 hover:bg-gray-500"
+                  ? "bg-accent w-8"
+                  : "bg-ink-faint hover:bg-ink-dim"
               }`}
               aria-label={`Switch to demo ${index + 1}`}
             />
@@ -338,14 +338,14 @@ export function TerminalDemo() {
                 const cleanText = cmd.text.replace("You: ", "");
                 displayText = (
                   <>
-                    <span className="text-blue-400">You:</span> {cleanText}
+                    <span className="text-ink">You:</span> {cleanText}
                   </>
                 );
               } else if (cmd.assistantText) {
                 const cleanText = cmd.text.replace("Claude: ", "");
                 displayText = (
                   <>
-                    <span className="text-purple-400">Claude:</span> {cleanText}
+                    <span className="text-ink">Claude:</span> {cleanText}
                   </>
                 );
               }

--- a/website/components/magicui/terminal.tsx
+++ b/website/components/magicui/terminal.tsx
@@ -13,18 +13,18 @@ export const Terminal = ({ children, className }: TerminalProps) => {
   return (
     <div
       className={cn(
-        "mx-auto rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl",
+        "mx-auto rounded-lg border border-rail bg-bg-soft",
         className,
       )}
     >
-      <div className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 sm:px-4 py-2 sm:py-3 rounded-t-lg">
+      <div className="flex items-center gap-2 border-b border-rail bg-bg-raise px-3 sm:px-4 py-2 sm:py-3 rounded-t-lg">
         <div className="flex gap-1.5 sm:gap-2">
-          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-red-500" />
-          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-yellow-500" />
-          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-green-500" />
+          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-ink-ghost" />
+          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-ink-ghost" />
+          <div className="h-2 w-2 sm:h-3 sm:w-3 rounded-full bg-ink-ghost" />
         </div>
         <div className="flex-1 text-center">
-          <span className="text-xs text-zinc-500 font-mono hidden sm:inline">
+          <span className="text-xs text-ink-label font-mono hidden sm:inline">
             terminal
           </span>
         </div>

--- a/website/content/docs/introduction.mdx
+++ b/website/content/docs/introduction.mdx
@@ -18,31 +18,31 @@ Zero-configuration memory for AI. Works instantly with embedded Redis, optional 
 ## Start building
 
 <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
-  <a href="/docs/quickstart" className="block p-6 rounded-lg border border-white/10 hover:border-white/20 transition-colors">
-    <h3 className="text-lg font-medium text-white mb-2">Quickstart →</h3>
-    <div className="text-gray-400 text-sm">Get started in 30 seconds - zero configuration</div>
+  <a href="/docs/quickstart" className="block p-6 rounded-lg border border-rail hover:border-rail-strong transition-colors">
+    <h3 className="text-lg font-medium text-ink mb-2">Quickstart →</h3>
+    <div className="text-ink-dim text-sm">Get started in 30 seconds - zero configuration</div>
   </a>
 
 <a
   href="/docs/ai-intelligence"
-  className="block p-6 rounded-lg border border-emerald-500/20 hover:border-emerald-500/40 bg-emerald-500/5 transition-colors"
+  className="block p-6 rounded-lg border border-rail hover:border-rail-strong bg-bg-soft transition-colors"
 >
   <div className="flex items-center">
-    <h3 className="text-lg font-medium text-white mt-0 mb-0">
+    <h3 className="text-lg font-medium text-ink mt-0 mb-0">
       AI Intelligence
     </h3>
-    <span className="ml-2 px-2 py-0.5 text-xs font-semibold text-emerald-400 bg-emerald-500/10 rounded-full">
+    <span className="ml-2 px-2 py-0.5 text-xs font-semibold text-ink bg-bg-raise border border-rail rounded-full">
       NEW
     </span>
   </div>
-  <div className="text-sm text-gray-400 mt-2">
+  <div className="text-sm text-ink-dim mt-2">
     Semantic search, entities, knowledge graphs
   </div>
 </a>
 
-  <a href="/docs/api-reference" className="block p-6 rounded-lg border border-white/10 hover:border-white/20 transition-colors">
-    <h3 className="text-lg font-medium text-white mb-2">API Reference →</h3>
-    <div className="text-gray-400 text-sm">Complete reference for all MCP tools</div>
+  <a href="/docs/api-reference" className="block p-6 rounded-lg border border-rail hover:border-rail-strong transition-colors">
+    <h3 className="text-lg font-medium text-ink mb-2">API Reference →</h3>
+    <div className="text-ink-dim text-sm">Complete reference for all MCP tools</div>
   </a>
 </div>
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "@n3wth/ui": "^0.6.1",
+        "@n3wth/ui": "^0.9.1",
         "@next/mdx": "^15.5.3",
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^9.3.0",
@@ -546,7 +546,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -568,7 +568,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -578,14 +578,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -687,14 +687,14 @@
       }
     },
     "node_modules/@n3wth/ui": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@n3wth/ui/-/ui-0.6.1.tgz",
-      "integrity": "sha512-kqwsiiQOuwDz9lqOJtDAVZppdYNqSKsWNwAmGHtwsmN/nbqjFIUUKMRMHgsjaUtdc58JGiKVZqbDOAkGVlFM6A==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@n3wth/ui/-/ui-0.9.1.tgz",
+      "integrity": "sha512-n447rRAgWvjU8RV4MIRTddhn0vDuTUl2lzJpBSB286NQfljq0eYtFYFS/PS2+zmFkUKCJ9gt94T01gm/gBWaJA==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^2.1.0",
+        "clsx": "^2.1.1",
         "iconoir-react": "^7.11.0",
-        "tailwind-merge": "^2.5.0"
+        "tailwind-merge": "^3.4.0"
       },
       "peerDependencies": {
         "gsap": "^3.12.0",
@@ -705,16 +705,6 @@
         "gsap": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@n3wth/ui/node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/@next/env": {
@@ -2105,7 +2095,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
       "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2127,7 +2117,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2505,14 +2495,14 @@
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
       "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2570,7 +2560,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2773,7 +2763,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/gray-matter": {
@@ -4798,7 +4788,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-range": {
@@ -5651,9 +5641,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
-      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5670,7 +5660,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5981,7 +5971,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@n3wth/ui": "^0.6.1",
+    "@n3wth/ui": "^0.9.1",
     "@next/mdx": "^15.5.3",
     "@react-three/drei": "^10.7.6",
     "@react-three/fiber": "^9.3.0",


### PR DESCRIPTION
Aligns r3.n3wth.com to the canonical wireframe design system (`@n3wth/ui/theme` v0.9.1). Recolor/refont/flatten only — layout, copy, and motion unchanged.

## Token table

| Surface | Before | After |
|---|---|---|
| Page bg | `bg-black` / `#000` | `bg-bg` `#08090b` |
| Panels (cards, terminal, chat) | `bg-white/[0.01–0.03]`, `bg-gray-900/30–50`, `bg-zinc-950`, `bg-black/40` | `bg-bg-soft` `#0d0e10` |
| Raised (active, chips, dropdowns, kbd) | `bg-white/[0.05–0.1]`, `bg-gray-800`, `bg-zinc-900`, `bg-gray-900` | `bg-bg-raise` `#131316` |
| Borders | `border-white/[0.05–0.1]`, `border-zinc-800`, `border-gray-800`, `var(--glass-border)` | `border-rail` (0.09) |
| Emphasis borders | `border-white/15–20`, `shadow-xl` dropdowns | `border-rail-strong` (0.17) |
| Primary text | `text-white` | `text-ink` `#f2f3f5` |
| Secondary text | `text-gray-300/400`, `text-white/60–90`, `grey-400` | `text-ink-dim` `#9aa0a8` |
| Faint/labels | `text-gray-500/600` | `text-ink-faint` / `text-ink-label` |
| Accent | `#a78bfa` purple override, blue/emerald/purple tints | `accent` `#ffffff` / `accent-dim` |
| Links (docs) | `text-blue-400` | `text-accent-dim hover:text-accent` |
| Display font | Mona Sans (lib default) | Geist |
| Brand font (logo) | JetBrains Mono | Geist Mono |
| Ease (GSAP + framer) | `power3.out`, `[0.25,0.46,0.45,0.94]` | `cubic-bezier(0.16,1,0.3,1)` |
| theme-color / OG image | `#4F46E5` / purple gradient | `#08090b` / flat bg+ink |

## Flattened (removed)

- Hero purple gradient + radial glow (`from-purple-950/20`, `rgba(120,100,255,0.12)`) — remnants the Feb cleanup missed
- Meteors render on home (gradient-tail + glow streaks); file kept, no longer imported by a route
- MemoryVisualization: rainbow node palette → ink scale, radial-gradient cores + box-shadow glows → flat fills, 6 gradient wash layers + central purple blur removed, SVG glow filter removed
- Logo "effect slideshow" (cycling gradient glows / colored orbit dots) → static flat wordmark
- `shadow-2xl/xl` on terminal, dropdowns, search modal → `bg-bg-raise` + `border-rail-strong`
- Dead decorative CSS in globals.css: aurora/gradient keyframes, `.glass-effect`, parallax, pulse-glow
- Glassmorphism backdrop-blur on hero badge, chat card, modal scrim (kept on sticky docs header, matching @n3wth/ui Nav)
- docs introduction.mdx emerald-tinted cards → rail/ink

## @n3wth/ui bump: attempted, succeeded

`0.6.1 → 0.9.1` + `@import '@n3wth/ui/theme'`. All used exports (Nav, Footer, Button, Section, SectionHeader, CommandBox) have identical APIs; build and render verified — no fallback to manual token mirroring needed. One cascade gotcha fixed: the lib's compiled `:root` is unlayered, so the Geist font overrides live in an unlayered `:root` (not `@layer base`) and next/font variables moved to `<html>`.

## Out of scope (intentionally)

- `/logo-preview` (LogoAccentOptions): self-contained accent-color exploration playground; recoloring it would defeat its purpose
- `app/page-original.tsx`: dead file (not routed), only kept type-compatible
- Prism `vsDark` syntax colors: functional code highlighting, not chrome

## Verify

- `next build --turbopack`: 23/23 pages ✓
- Built CSS: `--color-bg:#08090b`, ink/rail vars present; `a78bfa` 0 hits
- Runtime probe: body `rgb(8,9,11)` / `rgb(242,243,245)`, fonts resolve to Geist/Geist Fallback, Nav + Footer render
- Screenshots: /tmp/design-shots/r3-{before,after}.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)
